### PR TITLE
chore(*) adds jobs for building v8 arm binaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -118,10 +118,50 @@ jobs:
             echo "::set-output name=release_name::${{ github.event.inputs.release_name }}"
           fi
 
+  extract-arm:
+    name: "Extract Ubuntu 20.04 (focal) binary ARM from pre-built Docker image"
+    runs-on: ubuntu-latest
+    env:
+      RETENTION_DAYS: 2
+      VERSION: 10.5.8
+      RUNTIME: v8
+      OS: linux
+      ARCH: arm64
+
+    steps:
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: shrink/actions-docker-extract@v2
+        id: extract
+        with:
+          image: "ghcr.io/kong/ngx-wasm-runtimes:${{ env.RUNTIME }}-${{ env.VERSION }}-${{ env.OS }}-${{ env.ARCH }}"
+          path: "/wasmx/dist"
+      - name: Upload binary
+        uses: actions/upload-artifact@v2
+        if: ${{ github.event_name != 'pull_request' }}
+        with:
+          name: release-artifacts
+          path: ${{ steps.extract.outputs.destination }}
+          retention-days: ${{ env.RETENTION_DAYS }}
+
+      - id: assign-name
+        run: |
+          if [ "${{ github.event_name }}" = schedule ]; then
+            echo "::set-output name=release_name::nightly-$(date -u +%Y%m%d)"
+          else
+            echo "::set-output name=release_name::${{ github.event.inputs.release_name }}"
+          fi
+
   upload-artifacts:
     if: ${{ github.event_name != 'pull_request' }}
     name: Upload release artifacts
-    needs: [build]
+    needs: [build, extract-arm]
     runs-on: ubuntu-latest
     steps:
       - name: Retrieve sibling release artifacts

--- a/README.md
+++ b/README.md
@@ -1,2 +1,23 @@
 # ngx_wasm_runtimes
 Github Action for building Wasm runtimes for WasmX
+
+## Notes on ARM Binaries
+
+Compiling ARM binaries on GH hosted runners is only possible by emulating the
+compilation process. Building V8 in a emulated environment takes much longer
+than usual, in fact, more than 6 hours -- exceeding the execution time limit of
+a GHA job running on GHA runners.
+
+Since it's not possible to build V8 ARM binaries on GHA runners, the CI job that
+uploads ARM artifacts leverages a pre built Docker image containing the ARM
+deliverables. The job simply extracts a `.tar.gz` file representing the release
+artifact and uploads it to GH.
+
+### Pre-built Docker image
+
+The Docker image used in the CI job is built on top of `wasmx-build-ubuntu` and
+simply adds two layers to the image, one copying `ngx_wasm_module` source code
+and the other actually building and packaging V8.
+
+The image can be built by invoking `./util/build-packaged-v8-docker-image.sh`.
+This script is supposed to be invoked from an ARM machine.

--- a/assets/Dockerfile
+++ b/assets/Dockerfile
@@ -1,0 +1,17 @@
+FROM wasmx-build-ubuntu-arm
+
+ARG ARCH
+ARG OS
+ARG RUNTIME
+ARG RUNTIME_VERSION
+ARG NGX_WASM_MODULE
+
+ENV TARGET_NAME=$RUNTIME-$VERSION-$OS-$ARCH
+ENV PACKAGE_NAME=ngx_wasm_runtime-$RUNTIME-$RUNTIME_VERSION-$OS-$ARCH.tar.gz
+
+COPY ./$NGX_WASM_MODULE /wasmx
+
+RUN /wasmx/util/runtimes/$RUNTIME.sh /wasmx/work/$TARGET_NAME $RUNTIME_VERSION $ARCH && \
+    mkdir -p /wasmx/dist && \
+    cd /wasmx/work && \
+    tar czvpf /wasmx/dist/$PACKAGE_NAME $TARGET_NAME

--- a/util/build-packaged-v8-docker-image.sh
+++ b/util/build-packaged-v8-docker-image.sh
@@ -1,0 +1,55 @@
+OS=$(uname -s | tr '[:upper]' '[:lower:]')
+ARCH=$(uname -m)
+case $ARCH in
+    x86_64)  ARCH='amd64';;
+    aarch64) ARCH='arm64';;
+esac
+
+V8_VERSION=10.5.8
+
+NGX_WASM_MODULE=ngx_wasm_module
+DIR_NGX_WASM_MODULE=$PWD/$NGX_WASM_MODULE
+
+
+download_ngx_wasm_module() {
+    echo "Cloning ngx_wasm_module reposiory..."
+
+    if [[ ! -d "$DIR_NGX_WASM_MODULE" ]]; then
+      git clone git@github.com:Kong/ngx_wasm_module.git $NGX_WASM_MODULE
+    fi
+}
+
+build_wasmx_build_image() {
+    echo "Building wamx-build-image..."
+
+    if [[ -z "$(docker images -q wasmx-build-ubuntu)" ]]; then
+        pushd $DIR_NGX_WASM_MODULE
+            make act-build
+        popd
+    fi
+}
+
+build_packaged_v8_image() {
+    echo "Building V8..."
+
+    docker build \
+        -t ghcr.io/kong/ngx-wasm-runtimes:v8-$V8_VERSION-$OS-$ARCH \
+        --platform linux/$ARCH
+        --build-arg NGX_WASM_MODULE=$NGX_WASM_MODULE \
+        --build-arg OS=$OS \
+        --build-arg ARCH=$ARCH \
+        --build-arg RUNTIME=v8 \
+        --build-arg RUNTIME_VERSION=$V8_VERSION \
+        -f ./assets/Dockerfile .
+
+    docker push ghcr.io/kong/ngx-wasm-runtimes:v8-$V8_VERSION-$OS-$ARCH
+}
+
+if [[ ! "$ARCH" == "arm64" ]]; then
+    echo "Currently, this script should be invoked only in ARM linux" >&2
+    exit 1
+else
+    download_ngx_wasm_module
+    build_wasmx_build_image
+    build_packaged_v8_image
+fi


### PR DESCRIPTION
This PR adds a script for building an ARM docker image containing packaged v8 binaries -- built and packaged during image compilation. This image is then used in a GHA job, added by this PR, that extracts the packaged ARM binaries from it and uploads them to github artifacts. 

This semi-automated process is necessary due to the GHA job execution time limit of `6h`. Since GHA doesn't provide ARM runners, compilation needs to be executed over `qemu` which slow down the build substantially, indeed exceeding the `6h` limit making the job to be cancelled. 
